### PR TITLE
Eliminar fotos cargadas cuando se elimina registro en la BD

### DIFF
--- a/ASP.NET Core 3.1/Modulo 11 - Proyecto Final/PeliculasAPI/PeliculasAPI/Controllers/ActoresController.cs
+++ b/ASP.NET Core 3.1/Modulo 11 - Proyecto Final/PeliculasAPI/PeliculasAPI/Controllers/ActoresController.cs
@@ -104,7 +104,20 @@ namespace PeliculasAPI.Controllers
         [HttpDelete("{id}")]
         public async Task<ActionResult> Delete(int id)
         {
-            return await Delete<Actor>(id);
+            var existe = await context.Actores.AnyAsync(x => x.Id == id);
+
+            if (!existe)
+            {
+                return NotFound();
+            }
+
+            string rutaFoto = await context.Actores.Where(a => a.Id == id).Select(a => a.Foto).FirstOrDefaultAsync();
+            await almacenadorArchivos.BorrarArchivo(rutaFoto, contenedor);
+
+            context.Remove(new Actor() { Id = id });
+            await context.SaveChangesAsync();
+
+            return NoContent();
         }
     }
 }

--- a/ASP.NET Core 3.1/Modulo 11 - Proyecto Final/PeliculasAPI/PeliculasAPI/Controllers/PeliculasController.cs
+++ b/ASP.NET Core 3.1/Modulo 11 - Proyecto Final/PeliculasAPI/PeliculasAPI/Controllers/PeliculasController.cs
@@ -208,7 +208,19 @@ namespace PeliculasAPI.Controllers
         [HttpDelete("{id}")]
         public async Task<ActionResult> Delete(int id)
         {
-            return await Delete<Pelicula>(id);
+            var existe = await context.Peliculas.AnyAsync(x => x.Id == id);
+            if (!existe)
+            {
+                return NotFound();
+            }
+
+            string rutaFoto = await context.Peliculas.Where(a => a.Id == id).Select(a => a.Poster).FirstOrDefaultAsync();
+            await almacenadorArchivos.BorrarArchivo(rutaFoto, contenedor);
+
+            context.Remove(new Pelicula() { Id = id });
+            await context.SaveChangesAsync();
+
+            return NoContent();
         }
     }
 }


### PR DESCRIPTION
En las acciones de eliminar de los controladores Actores y Películas se eliminan los archivos que fueron cargados, como estaba al momento de eliminar un actor o una película los archivos de las fotos y posters quedaban ocupando espacio en el servidor (En mi caso que usaba almacenamiento local, aunque con Azure sucedería lo mismo).

Son las únicas dos entidades especiales que hasta el momento veo que no se deberían tratar con el método genérico de Delete en los controladores.